### PR TITLE
fix: blog post titles displayed correctly in search engines instead of slug URLs

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -6,8 +6,8 @@ import Footer from '../components/Footer.astro';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 
 const post = Astro.params;
-const dynamicTitle = post.slug === undefined ? SITE_TITLE : post.slug;
-const { image, description } = Astro.props;
+const { title, image, description } = Astro.props;
+const dynamicTitle = title || (post.slug === undefined ? SITE_TITLE : post.slug);
 const dynamicDescription = description === undefined ? SITE_DESCRIPTION : description;
 ---
 

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -27,7 +27,7 @@ blog.forEach((post) => {
 const { headings } = await entry.render();
 ---
 
-<Layout image={heroImage} description={description}>
+<Layout title={title} image={heroImage} description={description}>
   <main class="max-w-6xl mx-auto p-3 lg:p-6 lg:flex lg:grid lg:grid-cols-4">
     <article class="lg:col-span-3 bg-white shadow-md rounded-lg p-3 md:p-6 dark:bg-zinc-800">
       <h1 class="text-3xl font-semibold mb-4 dark:text-zinc-100">{title}</h1>


### PR DESCRIPTION
Fix the issue where Google search results display the slug-formatted title instead of the actual article title. (e.g. build-your-own-cursor-rules -> Build Your Own Cursor Rules)

1. src/layouts/Layout.astro:
    - Added title prop support
    - Updated title logic to use title || fallback pattern
2. src/layouts/Post.astro:
    - Now passes title={title} to Layout component